### PR TITLE
correctly dealing with undefined g:mapleader

### DIFF
--- a/pack/ttm/opt/aa/aux/prvdependence.vim
+++ b/pack/ttm/opt/aa/aux/prvdependence.vim
@@ -2,6 +2,9 @@
 com! PRVbuf setlocal buftype=nofile noswapfile bufhidden=wipe nobuflisted ft=python
 com! -nargs=+ PRVLeader cal PRVLeaderHelper(<f-args>)
 
+let s:mapleader = exists('g:mapleader') ? g:mapleader : "\\"
+let s:maplocalleader = exists('g:maplocalleader') ? g:maplocalleader : "\\"
+
 let g:prv = {'leaders':{}}
 fu! PRVLeaderHelper(...)
   if a:1 == 'd'
@@ -13,12 +16,7 @@ fu! PRVLeaderHelper(...)
 endf
 fu! PRVDeclareLeader(plug)
   cal assert_equal(type(a:plug), 1, 'only strings are accepted as arg to PRVDeclareLeader(plug)')
-  let g:prv.leaders[a:plug] = [g:mapleader, g:maplocalleader]
-  " exe 'let g:'.a:plug.'_keepleaders = [g:mapleader, g:maplocalleader]'
-  if has_key(g:prvset.leaders, a:plug)
-    let g:mapleader = g:prvset.leaders[a:plug][0]
-    let g:maplocalleader = g:prvset.leaders[a:plug][1]
-  en
+  let g:prv.leaders[a:plug] = [s:mapleader, s:maplocalleader]
 endf
 fu! PRVRestoreLeader(plug)
   let [g:mapleader, g:maplocalleader] = g:prv.leaders[a:plug]


### PR DESCRIPTION
I copied the code section to deal with an undefined leader from vimlatex.

AA now loades without errors. However, I removed references to the g:prvset variable,
since it is not declared here; only g:prv is.