### PR TITLE
Prv leader fix

### DIFF
--- a/pack/ttm/opt/prv/doc/prv.txt
+++ b/pack/ttm/opt/prv/doc/prv.txt
@@ -47,7 +47,7 @@ CONTENTS                                                            *prv-index*
                                                                *prv-plugins*
 
 PRV is a package, which currently consists of these plugins:
-* |prv|, the core: naviation strategies of files, tags and Vim interface.
+* |prv|, the core: navigation strategies of files, tags and Vim interface.
 * |aa|, algorithmic autoregulation: periodic note-taking for dedication
   tracking.
 * |realcolors|, 24 bit true color for Vim: on-the-fly tweak your color scheme,

--- a/pack/ttm/opt/prv/plugin/prv.vim
+++ b/pack/ttm/opt/prv/plugin/prv.vim
@@ -51,10 +51,12 @@ fu! PRVDeclareLeader(plug)
   if has_key(g:prvset.leaders, a:plug)
     let g:mapleader = g:prvset.leaders[a:plug][0]
     let g:maplocalleader = g:prvset.leaders[a:plug][1]
+    let [s:mapleader, s:maplocalleader] = [g:mapleader, g:maplocalleader]
   en
 endf
 fu! PRVRestoreLeader(plug)
   let [g:mapleader, g:maplocalleader] = g:prv.leaders[a:plug]
+  let [s:mapleader, s:maplocalleader] = [g:mapleader, g:maplocalleader]
 endf
 
 " insert one char {{{2

--- a/pack/ttm/opt/prv/plugin/prv.vim
+++ b/pack/ttm/opt/prv/plugin/prv.vim
@@ -8,6 +8,9 @@
 " FAPESP (project 2017/05838-3)
 " Ricardo Fabbri (PhD, IPRJ/UERJ)
 
+let s:mapleader = exists('g:mapleader') ? g:mapleader : "\\"
+let s:maplocalleader = exists('g:maplocalleader') ? g:maplocalleader : "\\"
+
 " Load Once: {{{1
 if exists("g:loaded_prvplugin") && (exists("g:prv_not_hacking") || exists("g:prv_not_hacking_all"))
  finish
@@ -43,7 +46,7 @@ fu! PRVLeaderHelper(...)
 endf
 fu! PRVDeclareLeader(plug)
   cal assert_equal(type(a:plug), 1, 'only strings are accepted as arg to PRVDeclareLeader(plug)')
-  let g:prv.leaders[a:plug] = [g:mapleader, g:maplocalleader]
+  let g:prv.leaders[a:plug] = [s:mapleader, s:maplocalleader]
   " exe 'let g:'.a:plug.'_keepleaders = [g:mapleader, g:maplocalleader]'
   if has_key(g:prvset.leaders, a:plug)
     let g:mapleader = g:prvset.leaders[a:plug][0]
@@ -275,7 +278,7 @@ fu! DecryptVimwiki() " encryption {{{2
       if &ft == 'vimwiki'
         "ec 'found vimwiki'
         " call input('1 Press any key to continue')
-        e
+          e
         " call input('3 Press any key to continue')
         setl key=
         " call input('4 Press any key to continue')
@@ -657,8 +660,10 @@ fu! PRVMkMappings(str) " {{{3
   en
 
   if a:str =~# 'a' " {{{4 auxleader
-    let l:foo = g:mapleader
-    let g:mapleader = g:prvset.leaders.prv[2]
+    if exists('g:prvset.leaders.prv')
+      let l:foo = s:mapleader
+      let g:mapleader = g:prvset.leaders.prv[2]
+    en
     nn <leader>a :exec "normal li".nr2char(getchar())."\e"<CR>
     nn <leader>A  :cal InsertAfterAfter()<CR>
     nn <leader>f  :cal system("wmctrl -ir " . v:windowid . " -b toggle,fullscreen")<CR>
@@ -688,7 +693,9 @@ fu! PRVMkMappings(str) " {{{3
     nn <leader>ep :PRVRedir v exec "normal g\<C-G>"<CR>xf"Dh
     nn <leader>eP :PRVRedir t exec "normal g\<C-G>"<CR>xf"Dh
     nn <leader>e<leader>p :PRVRedir n exec "normal g\<C-G>"<CR>xf"Dh
-    let g:mapleader = l:foo
+    if exists('g:prvset.leaders.prv')
+      let g:mapleader = l:foo
+    en
   en
 endf
 


### PR DESCRIPTION
A proposed fix for the case where the default leaders are being used,
and are not defined in vimrc. I need a review from @ttm  regarding the proper handling of prvset.
I noticed that @ttm 's  vimrc has all the leaders in prvset explicitly set. But if the user don't set them, they should be sensible defaults. The defaults are set in PRVInit/PRVDefineSettings but I don't know if they are sufficient to get sensible defaults; they seem like a stub:
```
  if !exists("g:prvset") " for user settings
    let g:prvset = {'leaders' : {}}
  en
```

At least my basic idea of setting the s: version of the leaders to the defaults is a proposed solution, even though it needs to be polished.

Moreover, I would need @ttm  to check my changes in lines 665,666,667 if I am handling correctly the case when prvset.leaders.prv is undefined.